### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A Model Context Protocol (MCP) server for running and parsing test results from 
 - Jest (JavaScript Testing Framework)
 - Go Tests
 
+<a href="https://glama.ai/mcp/servers/q001c11ec3"><img width="380" height="200" src="https://glama.ai/mcp/servers/q001c11ec3/badge" alt="Test Runner MCP server" /></a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Test Runner MCP](https://glama.ai/mcp/servers/q001c11ec3) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/q001c11ec3"><img width="380" height="200" src="https://glama.ai/mcp/servers/q001c11ec3/badge" alt="Test Runner MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.